### PR TITLE
Fixed colorMatrix function

### DIFF
--- a/standard.js
+++ b/standard.js
@@ -161,7 +161,9 @@ export default (compileShader, gl, draw) => {
 	return {
 		brightness,
 		brownie,
-		colorMatrix,
+		colorMatrix: (w, h, matrix) => {
+				colorMatrix(matrix);
+		},
 		contrast,
 		desaturate,
 		desaturateLuminance,


### PR DESCRIPTION
Hi, I found out that 
filter.addFilter('colorMatrix', [
      b,0,0,0,0,
      0,b,0,0,0,
      0,0,b,0,0,
      0,0,0,1,0
    ]);
doesn't work as expected. The commit fixed that. I would really appreciate if you merge it into your project and make it available via npm. Thanks for the amazing work you've done here.